### PR TITLE
Fix url typo in "get instance" example code

### DIFF
--- a/views/examples/instance.get.curl.jade
+++ b/views/examples/instance.get.curl.jade
@@ -3,4 +3,4 @@ div
     h2 Curl Example
     pre
         code
-            curl #{baseUrl}/item/#{query.params.instance_id || ':instance_id'}?access_token=#{accessToken}
+            curl #{baseUrl}/instance/#{query.params.instance_id || ':instance_id'}?access_token=#{accessToken}


### PR DESCRIPTION
Currently says `GET /instance/:instance_id` up top and `GET /item/:instance_id` in the copy/paste demo area.
